### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -12,17 +12,17 @@ NCP5623	KEYWORD1
 # Methods and Functions (KEYWORD2)
 ##################################
 begin	KEYWORD2
-setColor    KEYWORD2
-setChannel  KEYWORD2
-setCurrent  KEYWORD2
-setRed  KEYWORD2
-setGreen    KEYWORD2
-setBlue KEYWORD2
-mapColors   KEYWORD2
-writeReg    KEYWORD2
+setColor	KEYWORD2
+setChannel	KEYWORD2
+setCurrent	KEYWORD2
+setRed	KEYWORD2
+setGreen	KEYWORD2
+setBlue	KEYWORD2
+mapColors	KEYWORD2
+writeReg	KEYWORD2
 
 ###########################################
 # Constants (LITERAL1)
 ###########################################
-NCP5623_DEFAULT_ADDR LITERAL1
-NCP5623_REG_ILED    LITERAL1
+NCP5623_DEFAULT_ADDR	LITERAL1
+NCP5623_REG_ILED	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords